### PR TITLE
Feature/job clusters in run dto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.edmunds</groupId>
     <artifactId>databricks-rest-client</artifactId>
-    <version>3.1.2.12</version>
+    <version>3.1.2.13</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A simple java rest client to interact with the Databricks Rest Service

--- a/src/main/java/com/edmunds/rest/databricks/DTO/jobs/RunDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/jobs/RunDTO.java
@@ -60,6 +60,8 @@ public class RunDTO implements Serializable {
   private long cleanupDuration;
   @JsonProperty("trigger")
   private TriggerTypeDTO trigger;
+  @JsonProperty("job_clusters")
+  private JobCluster[] jobClusters;
 
   // custom parameters
   @JsonProperty("run_name")

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
@@ -21,6 +21,7 @@ import com.edmunds.rest.databricks.DTO.clusters.AutoScaleDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterEventDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterEventTypeDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterInfoDTO;
+import com.edmunds.rest.databricks.DTO.clusters.ListOrderDTO;
 import com.edmunds.rest.databricks.DTO.clusters.NodeTypeDTO;
 import com.edmunds.rest.databricks.DTO.clusters.SparkVersionDTO;
 import com.edmunds.rest.databricks.DTO.jobs.NewClusterDTO;
@@ -173,7 +174,7 @@ public interface ClusterService {
    * @throws DatabricksRestException any errors with the request
    */
   List<ClusterEventDTO> listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter,
-      int offset, int limit) throws IOException,
+                                   int offset, int limit, ListOrderDTO order) throws IOException,
       DatabricksRestException;
 
   /**

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
@@ -25,6 +25,7 @@ import com.edmunds.rest.databricks.DTO.clusters.ClusterEventDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterEventTypeDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterInfoDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterStateDTO;
+import com.edmunds.rest.databricks.DTO.clusters.ListOrderDTO;
 import com.edmunds.rest.databricks.DTO.clusters.NodeTypeDTO;
 import com.edmunds.rest.databricks.DTO.clusters.SparkVersionDTO;
 import com.edmunds.rest.databricks.DTO.jobs.NewClusterDTO;
@@ -163,7 +164,7 @@ public final class ClusterServiceImpl extends DatabricksService implements Clust
 
   @Override
   public List<ClusterEventDTO> listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter,
-      int offset, int limit) throws
+                                          int offset, int limit, ListOrderDTO order) throws
       IOException,
       DatabricksRestException {
     Map<String, Object> data = new HashMap<>();
@@ -171,6 +172,7 @@ public final class ClusterServiceImpl extends DatabricksService implements Clust
     data.put("event_types", eventsToFilter);
     data.put("offset", offset);
     data.put("limit", limit);
+    data.put("order", order);
     byte[] responseBody = client.performQuery(RequestMethod.POST, "/clusters/events", data);
     ClusterEventsDTO clusterEvents = this.mapper.readValue(responseBody, ClusterEventsDTO.class);
     return clusterEvents.getEvents();

--- a/src/test/java/com/edmunds/rest/databricks/service/ClusterServiceTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/ClusterServiceTest.java
@@ -30,6 +30,7 @@ import com.edmunds.rest.databricks.DTO.clusters.ClusterEventDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterEventTypeDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterInfoDTO;
 import com.edmunds.rest.databricks.DTO.clusters.ClusterStateDTO;
+import com.edmunds.rest.databricks.DTO.clusters.ListOrderDTO;
 import com.edmunds.rest.databricks.DTO.EbsVolumeTypeDTO;
 import com.edmunds.rest.databricks.DatabricksRestException;
 import com.edmunds.rest.databricks.fixtures.ClusterDependentTest;
@@ -152,7 +153,7 @@ public class ClusterServiceTest extends ClusterDependentTest {
   public void listEvents_whenCalled_showsEvents() throws IOException, DatabricksRestException {
     ClusterInfoDTO[] clusterInfoDTO = service.list();
     String clusterId = clusterInfoDTO[0].getClusterId();
-    List<ClusterEventDTO> events = service.listEvents(clusterId, new ClusterEventTypeDTO[0], 0, 50);
+    List<ClusterEventDTO> events = service.listEvents(clusterId, new ClusterEventTypeDTO[0], 0, 50, ListOrderDTO.DESC);
     assertTrue(events.size() > 0);
   }
 }


### PR DESCRIPTION
[User Story 3327](https://dev.azure.com/bp-product/DBricks_Optimizer/_workitems/edit/3327): Update databricks-rest-client to support ordering in cluster events, and job_clusters in RunDTO:

- In order to infer driver_instance_pool_id and instance_pool_id from databricks RunDTO entities, need to add "job_clusters" field into [RunDTO](https://github.com/BlueprintTechnologies/databricks-rest-client/blob/master/src/main/java/com/edmunds/rest/databricks/DTO/jobs/RunDTO.java#L29)

- In order to work with pagination - parameters `limit` and `offset` with default/missing ordering, the API requires explicitly specifying start/end timestamps in that case. Adding `ListOrderDTO order` parameter into the method fixes our problem