### PR TITLE
Version 3.1.2.18: optional filtering cluster events with timestamps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.edmunds</groupId>
     <artifactId>databricks-rest-client</artifactId>
-    <version>3.1.2.17</version>
+    <version>3.1.2.18</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A simple java rest client to interact with the Databricks Rest Service

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterService.java
@@ -174,8 +174,10 @@ public interface ClusterService {
    * @throws DatabricksRestException any errors with the request
    */
   List<ClusterEventDTO> listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter,
-                                   int offset, int limit, ListOrderDTO order) throws IOException,
-      DatabricksRestException;
+                                   Integer offset, Integer limit,
+                                   ListOrderDTO order,
+                                   Long startTime, Long endTime)
+      throws IOException, DatabricksRestException;
 
   /**
    * Given a cluster settings DTO object it will:

--- a/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
+++ b/src/main/java/com/edmunds/rest/databricks/service/ClusterServiceImpl.java
@@ -164,15 +164,19 @@ public final class ClusterServiceImpl extends DatabricksService implements Clust
 
   @Override
   public List<ClusterEventDTO> listEvents(String clusterId, ClusterEventTypeDTO[] eventsToFilter,
-                                          int offset, int limit, ListOrderDTO order) throws
-      IOException,
-      DatabricksRestException {
+                                          Integer offset, Integer limit,
+                                          ListOrderDTO order,
+                                          Long startTime, Long endTime)
+      throws IOException, DatabricksRestException {
+
     Map<String, Object> data = new HashMap<>();
     data.put("cluster_id", clusterId);
     data.put("event_types", eventsToFilter);
     data.put("offset", offset);
     data.put("limit", limit);
     data.put("order", order);
+    data.put("start_time", startTime);
+    data.put("end_time", endTime);
     byte[] responseBody = client.performQuery(RequestMethod.POST, "/clusters/events", data);
     ClusterEventsDTO clusterEvents = this.mapper.readValue(responseBody, ClusterEventsDTO.class);
     return clusterEvents.getEvents();

--- a/src/test/java/com/edmunds/rest/databricks/service/ClusterServiceTest.java
+++ b/src/test/java/com/edmunds/rest/databricks/service/ClusterServiceTest.java
@@ -37,6 +37,7 @@ import com.edmunds.rest.databricks.fixtures.ClusterDependentTest;
 import com.edmunds.rest.databricks.request.CreateClusterRequest;
 import com.edmunds.rest.databricks.request.EditClusterRequest;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import org.testng.annotations.Test;
@@ -153,7 +154,10 @@ public class ClusterServiceTest extends ClusterDependentTest {
   public void listEvents_whenCalled_showsEvents() throws IOException, DatabricksRestException {
     ClusterInfoDTO[] clusterInfoDTO = service.list();
     String clusterId = clusterInfoDTO[0].getClusterId();
-    List<ClusterEventDTO> events = service.listEvents(clusterId, new ClusterEventTypeDTO[0], 0, 50, ListOrderDTO.DESC);
+    Long now = Instant.now().toEpochMilli();
+    List<ClusterEventDTO> events = service.listEvents(
+        clusterId, new ClusterEventTypeDTO[0], 0, 50, ListOrderDTO.DESC, now - 1000000, now
+    );
     assertTrue(events.size() > 0);
   }
 }


### PR DESCRIPTION
ClusterService.listEvents now have got nullable startTime/endTime parameters; offset and limit now are nullable too