### PR TITLE
[3.1.2.49] cluster node types DTO update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.edmunds</groupId>
     <artifactId>databricks-rest-client</artifactId>
-    <version>3.1.2.48</version>
+    <version>3.1.2.49</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A simple java rest client to interact with the Databricks Rest Service

--- a/src/main/java/com/edmunds/rest/databricks/DTO/clusters/ClusterCloudProviderNodeInstanceTypeDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/clusters/ClusterCloudProviderNodeInstanceTypeDTO.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Edmunds.com, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.edmunds.rest.databricks.DTO.clusters;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ *
+ */
+@Data
+public class ClusterCloudProviderNodeInstanceTypeDTO implements Serializable {
+  @JsonProperty("instance_type_id")
+  private String instanceTypeId;
+
+  @JsonProperty("local_disks")
+  private int localDisks;
+
+  @JsonProperty("local_disk_size_gb")
+  private int localDiskSizeGb;
+
+  @JsonProperty("instance_family")
+  private String instanceFamily;
+
+  @JsonProperty("swap_size")
+  private String swapSize;
+
+  @JsonProperty("is_graviton")
+  private boolean isGraviton;
+
+  // note: currently provided on AWS only, and is true for fleet instance type
+  @JsonProperty("is_virtual")
+  private boolean isVirtual;
+}

--- a/src/main/java/com/edmunds/rest/databricks/DTO/clusters/NodeTypeDTO.java
+++ b/src/main/java/com/edmunds/rest/databricks/DTO/clusters/NodeTypeDTO.java
@@ -32,17 +32,36 @@ public class NodeTypeDTO implements Serializable {
   private int memoryMb;
   @JsonProperty("num_cores")
   private float numCores;
+  @JsonProperty("num_gpus")
+  private float numGpus;
   @JsonProperty("description")
   private String description;
+  @JsonProperty("category")
+  private String category;
+  @JsonProperty("support_ebs_volumes")
+  private String supportEbsVolumes;
+  @JsonProperty("support_cluster_tags")
+  private String supportClusterTags;
   @JsonProperty("instance_type_id")
   private String instanceTypeId;
   @JsonProperty("is_deprecated")
   private boolean isDeprecated;
+  @JsonProperty("is_hidden")
+  private boolean isHidden;
+  @JsonProperty("is_graviton")
+  private boolean isGraviton;
   @JsonProperty("photon_driver_capable")
   private boolean photonDriverCapable;
   @JsonProperty("photon_worker_capable")
   private boolean photonWorkerCapable;
+  @JsonProperty("is_encrypted_in_transit")
+  private boolean isEncryptedInTransit;
+  @JsonProperty("require_fabric_manager")
+  private boolean requireFabricManager;
   @JsonProperty("node_info")
   private ClusterCloudProviderNodeInfoDTO nodeInfo;
+  @JsonProperty("node_instance_type")
+  private ClusterCloudProviderNodeInstanceTypeDTO nodeInstanceType;
+
 
 }


### PR DESCRIPTION
[3.1.2.49] cluster node types DTO update: add fields category, num_gpus, support_ebs_volumes, support_cluster_tags, is_graviton, is_hidden, node_instance_type